### PR TITLE
Add TryNow Swift package with modular VTO scaffolding

### DIFF
--- a/TryNow/.gitignore
+++ b/TryNow/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+Build/

--- a/TryNow/Package.swift
+++ b/TryNow/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "TryNow",
+    platforms: [
+        .iOS(.v17)
+    ],
+    products: [
+        .library(name: "FaceTryOn", targets: ["FaceTryOn"]),
+        .library(name: "FootTryOn", targets: ["FootTryOn"]),
+        .library(name: "SizeAdvisor", targets: ["SizeAdvisor"]),
+        .library(name: "CatalogModelSwap", targets: ["CatalogModelSwap"]),
+        .library(name: "Analytics", targets: ["Analytics"]),
+        .library(name: "Privacy", targets: ["Privacy"]),
+        .library(name: "TryNowPDPKit", targets: ["TryNowPDPKit"]),
+        .executable(name: "TryNowApp", targets: ["TryNowApp"])
+    ],
+    targets: [
+        .target(name: "FaceTryOn"),
+        .testTarget(name: "FaceTryOnTests", dependencies: ["FaceTryOn"]),
+        .target(name: "FootTryOn"),
+        .testTarget(name: "FootTryOnTests", dependencies: ["FootTryOn"]),
+        .target(name: "SizeAdvisor"),
+        .testTarget(name: "SizeAdvisorTests", dependencies: ["SizeAdvisor"]),
+        .target(name: "CatalogModelSwap"),
+        .testTarget(name: "CatalogModelSwapTests", dependencies: ["CatalogModelSwap"]),
+        .target(name: "Analytics"),
+        .target(name: "Privacy"),
+        .target(name: "TryNowPDPKit", dependencies: ["FaceTryOn"]),
+        .testTarget(name: "TryNowPDPKitTests", dependencies: ["TryNowPDPKit"]),
+        .executableTarget(
+            name: "TryNowApp",
+            dependencies: ["FaceTryOn", "FootTryOn", "SizeAdvisor", "CatalogModelSwap", "Analytics", "Privacy"]
+        ),
+        .testTarget(name: "TryNowAppTests", dependencies: ["TryNowApp"])
+    ]
+)

--- a/TryNow/Sources/Analytics/AnalyticsService.swift
+++ b/TryNow/Sources/Analytics/AnalyticsService.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public protocol AnalyticsEvent {
+    var name: String { get }
+    var parameters: [String: String] { get }
+}
+
+public protocol AnalyticsService {
+    func log(_ event: AnalyticsEvent)
+}
+
+public struct ConsoleAnalyticsService: AnalyticsService {
+    public init() {}
+    public func log(_ event: AnalyticsEvent) {
+        print("\(event.name): \(event.parameters)")
+    }
+}

--- a/TryNow/Sources/CatalogModelSwap/ModelSwapProvider.swift
+++ b/TryNow/Sources/CatalogModelSwap/ModelSwapProvider.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+
+public protocol ModelSwapProvider {
+    func generateComposite(modelImage: UIImage, garmentMask: CGImage) async -> UIImage
+}
+
+public final class MockModelSwapProvider: ModelSwapProvider {
+    public init() {}
+    public func generateComposite(modelImage: UIImage, garmentMask: CGImage) async -> UIImage {
+        modelImage
+    }
+}
+#else
+public protocol ModelSwapProvider {}
+public final class MockModelSwapProvider: ModelSwapProvider {
+    public init() {}
+}
+#endif

--- a/TryNow/Sources/FaceTryOn/FaceTryOnService.swift
+++ b/TryNow/Sources/FaceTryOn/FaceTryOnService.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public protocol FaceTryOnService {
+    func availableStyles() async -> [String]
+}
+
+public struct MockFaceTryOnService: FaceTryOnService {
+    public init() {}
+    public func availableStyles() async -> [String] {
+        ["Default"]
+    }
+}

--- a/TryNow/Sources/FaceTryOn/FaceTryOnView.swift
+++ b/TryNow/Sources/FaceTryOn/FaceTryOnView.swift
@@ -1,0 +1,56 @@
+#if canImport(SwiftUI) && canImport(RealityKit) && canImport(ARKit)
+import SwiftUI
+import RealityKit
+import ARKit
+
+public struct FaceTryOnView: View {
+    @StateObject private var viewModel = FaceTryOnViewModel()
+
+    public init() {}
+
+    public var body: some View {
+        VStack {
+            ARViewContainer(viewModel: viewModel)
+            Text("Fit Confidence: \(viewModel.fitConfidence, specifier: "%.1f")")
+        }
+        .navigationTitle("Face Try-On")
+    }
+}
+
+final class FaceTryOnViewModel: ObservableObject {
+    @Published var fitConfidence: Double = 0.0
+    let service: FaceTryOnService
+
+    init(service: FaceTryOnService = MockFaceTryOnService()) {
+        self.service = service
+    }
+
+    func start() {}
+}
+
+struct ARViewContainer: UIViewRepresentable {
+    @ObservedObject var viewModel: FaceTryOnViewModel
+
+    func makeUIView(context: Context) -> ARView {
+        let arView = ARView(frame: .zero)
+        let config = ARFaceTrackingConfiguration()
+        arView.session.run(config)
+        if let anchor = try? FaceEyewearScene.loadEyewear() {
+            arView.scene.anchors.append(anchor)
+        }
+        return arView
+    }
+
+    func updateUIView(_ uiView: ARView, context: Context) {}
+}
+
+enum FaceEyewearScene {
+    static func loadEyewear() throws -> AnchorEntity {
+        AnchorEntity()
+    }
+}
+#else
+public struct FaceTryOnView {
+    public init() {}
+}
+#endif

--- a/TryNow/Sources/FootTryOn/FootTryOnView.swift
+++ b/TryNow/Sources/FootTryOn/FootTryOnView.swift
@@ -1,0 +1,16 @@
+#if canImport(SwiftUI) && canImport(Vision) && canImport(AVFoundation)
+import SwiftUI
+import Vision
+import AVFoundation
+
+public struct FootTryOnView: View {
+    public init() {}
+    public var body: some View {
+        Text("Foot Try-On")
+    }
+}
+#else
+public struct FootTryOnView {
+    public init() {}
+}
+#endif

--- a/TryNow/Sources/Privacy/ConsentView.swift
+++ b/TryNow/Sources/Privacy/ConsentView.swift
@@ -1,0 +1,24 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import Combine
+
+public struct ConsentView: View {
+    @AppStorage("onDeviceProcessing") private var onDevice = true
+    public init() {}
+    public var body: some View {
+        Form {
+            Toggle("Process on my device", isOn: $onDevice)
+        }
+        .navigationTitle("Privacy")
+    }
+}
+
+public func eraseDataAction() {
+    // Placeholder for clearing caches and keychain
+}
+#else
+public struct ConsentView {
+    public init() {}
+}
+public func eraseDataAction() {}
+#endif

--- a/TryNow/Sources/SizeAdvisor/SizeAdvisorEngine.swift
+++ b/TryNow/Sources/SizeAdvisor/SizeAdvisorEngine.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct SizeRecommendation {
+    public let size: String
+    public let confidence: Double
+    public init(size: String, confidence: Double) {
+        self.size = size
+        self.confidence = confidence
+    }
+}
+
+public protocol SizeAdvisorEngineProtocol {
+    func recommend(height: Double, weight: Double, preference: String) -> SizeRecommendation
+}
+
+public final class SizeAdvisorEngine: SizeAdvisorEngineProtocol {
+    public init() {}
+    public func recommend(height: Double, weight: Double, preference: String) -> SizeRecommendation {
+        let size = height > 170 ? "M" : "S"
+        return SizeRecommendation(size: size, confidence: 0.5)
+    }
+}

--- a/TryNow/Sources/SizeAdvisor/SizeAdvisorView.swift
+++ b/TryNow/Sources/SizeAdvisor/SizeAdvisorView.swift
@@ -1,0 +1,42 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+public struct SizeAdvisorView: View {
+    @State private var height: String = ""
+    @State private var weight: String = ""
+    @State private var preference: String = "Regular"
+    @State private var result: SizeRecommendation?
+
+    let engine: SizeAdvisorEngineProtocol
+
+    public init(engine: SizeAdvisorEngineProtocol = SizeAdvisorEngine()) {
+        self.engine = engine
+    }
+
+    public var body: some View {
+        Form {
+            TextField("Height (cm)", text: $height)
+                .keyboardType(.decimalPad)
+            TextField("Weight (kg)", text: $weight)
+                .keyboardType(.decimalPad)
+            Picker("Fit", selection: $preference) {
+                Text("Slim").tag("Slim")
+                Text("Regular").tag("Regular")
+            }
+            Button("Recommend") {
+                let h = Double(height) ?? 0
+                let w = Double(weight) ?? 0
+                result = engine.recommend(height: h, weight: w, preference: preference)
+            }
+            if let result {
+                Text("Size: \(result.size) ±\(String(format: "%.1f", result.confidence))")
+            }
+        }
+        .navigationTitle("Size Advisor")
+    }
+}
+#else
+public struct SizeAdvisorView {
+    public init(engine: SizeAdvisorEngineProtocol = SizeAdvisorEngine()) {}
+}
+#endif

--- a/TryNow/Sources/TryNowApp/TryNowApp.swift
+++ b/TryNow/Sources/TryNowApp/TryNowApp.swift
@@ -1,0 +1,37 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import FaceTryOn
+import FootTryOn
+import SizeAdvisor
+import Privacy
+
+@main
+public struct TryNowApp: App {
+    public init() {}
+    public var body: some Scene {
+        WindowGroup {
+            HomeView()
+        }
+    }
+}
+
+struct HomeView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                NavigationLink("Face Try-On") { FaceTryOnView() }
+                NavigationLink("Footwear Try-On") { FootTryOnView() }
+                NavigationLink("Size Advisor") { SizeAdvisorView() }
+                NavigationLink("Privacy") { ConsentView() }
+            }
+            .navigationTitle("TryNow")
+        }
+    }
+}
+#else
+public struct TryNowApp {}
+@main
+public enum TryNowAppMain {
+    public static func main() {}
+}
+#endif

--- a/TryNow/Sources/TryNowPDPKit/TryOnButton.swift
+++ b/TryNow/Sources/TryNowPDPKit/TryOnButton.swift
@@ -1,0 +1,45 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import FaceTryOn
+
+public struct TryOnResult {
+    public let timeSpent: TimeInterval
+    public let variant: String
+    public let snapshotURL: URL?
+    public init(timeSpent: TimeInterval, variant: String, snapshotURL: URL?) {
+        self.timeSpent = timeSpent
+        self.variant = variant
+        self.snapshotURL = snapshotURL
+    }
+}
+
+public struct TryOnButton: View {
+    let style: ButtonStyleType
+    let onComplete: (TryOnResult) -> Void
+    @State private var presented = false
+
+    public enum ButtonStyleType {
+        case filled
+    }
+
+    public init(style: ButtonStyleType = .filled, onComplete: @escaping (TryOnResult) -> Void) {
+        self.style = style
+        self.onComplete = onComplete
+    }
+
+    public var body: some View {
+        Button("Try On") { presented = true }
+            .sheet(isPresented: $presented) {
+                FaceTryOnView()
+                    .onDisappear {
+                        let result = TryOnResult(timeSpent: 0, variant: "default", snapshotURL: nil)
+                        onComplete(result)
+                    }
+            }
+    }
+}
+#else
+public struct TryOnButton {
+    public init(style: Int = 0, onComplete: @escaping (Any) -> Void) {}
+}
+#endif

--- a/TryNow/Tests/CatalogModelSwapTests/CatalogModelSwapTests.swift
+++ b/TryNow/Tests/CatalogModelSwapTests/CatalogModelSwapTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import CatalogModelSwap
+
+final class CatalogModelSwapTests: XCTestCase {
+    func testMockInit() {
+        _ = MockModelSwapProvider()
+    }
+}

--- a/TryNow/Tests/FaceTryOnTests/FaceTryOnTests.swift
+++ b/TryNow/Tests/FaceTryOnTests/FaceTryOnTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import FaceTryOn
+
+final class FaceTryOnTests: XCTestCase {
+    func testMockStyles() async throws {
+        let service = MockFaceTryOnService()
+        let styles = await service.availableStyles()
+        XCTAssertEqual(styles.first, "Default")
+    }
+}

--- a/TryNow/Tests/FootTryOnTests/FootTryOnTests.swift
+++ b/TryNow/Tests/FootTryOnTests/FootTryOnTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import FootTryOn
+
+final class FootTryOnTests: XCTestCase {
+    func testPlaceholder() {
+        _ = FootTryOnView()
+    }
+}

--- a/TryNow/Tests/SizeAdvisorTests/SizeAdvisorTests.swift
+++ b/TryNow/Tests/SizeAdvisorTests/SizeAdvisorTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import SizeAdvisor
+
+final class SizeAdvisorTests: XCTestCase {
+    func testRecommendation() {
+        let engine = SizeAdvisorEngine()
+        let result = engine.recommend(height: 180, weight: 75, preference: "Regular")
+        XCTAssertEqual(result.size, "M")
+    }
+}

--- a/TryNow/Tests/TryNowAppTests/TryNowAppTests.swift
+++ b/TryNow/Tests/TryNowAppTests/TryNowAppTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import TryNowApp
+
+final class TryNowAppTests: XCTestCase {
+    func testAppInit() {
+        _ = TryNowApp()
+    }
+}

--- a/TryNow/Tests/TryNowPDPKitTests/TryNowPDPKitTests.swift
+++ b/TryNow/Tests/TryNowPDPKitTests/TryNowPDPKitTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import TryNowPDPKit
+
+final class TryNowPDPKitTests: XCTestCase {
+    func testButtonInit() {
+        _ = TryOnButton(style: 0) { _ in }
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold modular Swift package for TryNow with FaceTryOn, FootTryOn, SizeAdvisor, CatalogModelSwap, Analytics, Privacy, PDP SDK, and app target
- implement stubbed SwiftUI views, services, and mock implementations for each module
- add basic XCTest suites

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b12f0cec088321af609a6ebe811f72